### PR TITLE
Fix: determine correct tag for release notes

### DIFF
--- a/generateNotes.js
+++ b/generateNotes.js
@@ -2,7 +2,10 @@ const changelog = require('conventional-changelog')
 const parseUrl = require('github-url-from-git')
 const execSync = require('child_process').execSync;
 
-const lastTag = () => execSync('git describe --tags --match "v[0-9]*" --abbrev=0 origin/master', { encoding: 'utf8' }).trim();
+const lastTag = () => execSync(
+    'git describe --tags --match "v[0-9]*" --exclude="*dev*" --abbrev=0 origin/master',
+    { encoding: 'utf8' }
+).trim();
 
 module.exports = function (pluginConfig, {pkg}, cb) {
   const repository = pkg.repository ? parseUrl(pkg.repository.url) : null

--- a/generateNotes.js
+++ b/generateNotes.js
@@ -2,9 +2,7 @@ const changelog = require('conventional-changelog')
 const parseUrl = require('github-url-from-git')
 const execSync = require('child_process').execSync;
 
-const describe = () => execSync('git describe --tags origin/master', { encoding: 'utf8' });
-const baseTag = (tag) => tag.replace(/(v[0-9.]+)(.*)/, '$1').trim();
-const lastTag = () => baseTag(describe());
+const lastTag = () => execSync('git describe --tags --abbrev=0 origin/master', { encoding: 'utf8' }).trim();
 
 module.exports = function (pluginConfig, {pkg}, cb) {
   const repository = pkg.repository ? parseUrl(pkg.repository.url) : null

--- a/generateNotes.js
+++ b/generateNotes.js
@@ -2,7 +2,7 @@ const changelog = require('conventional-changelog')
 const parseUrl = require('github-url-from-git')
 const execSync = require('child_process').execSync;
 
-const lastTag = () => execSync('git describe --tags --abbrev=0 origin/master', { encoding: 'utf8' }).trim();
+const lastTag = () => execSync('git describe --tags --match "v[0-9]*" --abbrev=0 origin/master', { encoding: 'utf8' }).trim();
 
 module.exports = function (pluginConfig, {pkg}, cb) {
   const repository = pkg.repository ? parseUrl(pkg.repository.url) : null


### PR DESCRIPTION
Closes #2 by taking the latest official release tag when calculating release notes.

The package now requires git 2.13+ for to the `--exclude` option of `git describe`

