### PR TITLE
fix: skip publish of releases without end-user facing changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project has been tested in Travis-CI and Jenkins builds.
         // package.json
         "release": {
           "analyzeCommits": "@telerik/semantic-prerelease/analyzeCommits",
+          "generateNotes": "@telerik/semantic-prerelease/generateNotes",
           "getLastRelease": "@telerik/semantic-prerelease/getLastRelease",
           "verifyConditions": "@telerik/semantic-prerelease/verifyConditions",
           "verifyRelease": "@telerik/semantic-prerelease/verifyRelease"

--- a/analyzeCommits.js
+++ b/analyzeCommits.js
@@ -1,4 +1,18 @@
 const analyzeCommits = require('@semantic-release/commit-analyzer')
+const SemanticReleaseError = require('@semantic-release/error')
+const execSync = require('child_process').execSync;
+
+const until = f => array => {
+  const first = array[0];
+
+  if (!first || f(first)) {
+    return [];
+  }
+
+  return [ first, ...until(f)(array.slice(1)) ];
+};
+
+const lastTaggedRelease = () => execSync('git rev-list -1 `git describe --tags --abbrev=0 --match "v[0-9]*"`', { encoding: 'utf8' }).trim();
 
 module.exports = function (pluginConfig, config, cb) {
   // run standard commit analysis
@@ -6,10 +20,14 @@ module.exports = function (pluginConfig, config, cb) {
     const branch = config.env.TRAVIS_BRANCH || config.env.GIT_LOCAL_BRANCH;
     const branchTags = config.options.branchTags;
     const distTag = branchTags && branchTags[branch];
-    let releaseType = type;
 
-    // if branch publishes a dist-tag
-    if (type && distTag) {
+    // use default behavior if not publishing a custom dist-tag
+    if (!distTag) {
+      return cb(error, type);
+    }
+
+    let releaseType = type;
+    if (type) {
       // map all types of releases to prereleases
       releaseType = {
         'major': 'premajor',
@@ -20,7 +38,23 @@ module.exports = function (pluginConfig, config, cb) {
       console.log("Publishing a " + releaseType + " release.");
     }
 
-    cb(error, releaseType);
+    // suppress NPM releases of non-feature commits (chore/docs/etc)
+    const lastReleaseHash = lastTaggedRelease();
+    const untilLastRelease = until(commit => commit.hash === lastReleaseHash);
+    const commits = untilLastRelease(config.commits);
+    const commitSubset = Object.assign({}, config, { commits });
+
+    analyzeCommits(pluginConfig, commitSubset, function(_, type) {
+      if (!type) {
+        // commits since last dist-tag release are empty, suppress release
+        return cb(new SemanticReleaseError(
+          'There are no relevant changes, so no new version is released.',
+          'ENOCHANGE'
+        ));
+      }
+
+      cb(error, releaseType);
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist-tag"
   ],
   "dependencies": {
+    "@krux/condition-jenkins": "^1.0.1",
     "semantic-release": "^4.3.5"
   },
   "engines": {


### PR DESCRIPTION
At this time, every commit in a prerelease branch publishes new package versions, no matter what the changes are. This PR limits this, so that only significant changes are published in the release channel.