### PR TITLE
fix: fallback to origin/master in case of missing gitHead

### DIFF
--- a/getLastRelease.js
+++ b/getLastRelease.js
@@ -19,6 +19,10 @@ module.exports = function (pluginConfig, config, cb) {
   }
 
   return defaultLastRelease(pluginConfig, config, function(err, res) {
+    if (!res.gitHead) {
+      res.gitHead = 'origin/master';
+    }
+
     if (distTag) {
       console.log(`Reverting back to ${oldTag} tag.`);
       config.npm.tag = oldTag;


### PR DESCRIPTION
The latest release should be determined from the remote `master` branch in case the NPM registry metadata lacks `gitHead`.