### PR TITLE
fix: fallback to last official tag for gitHead

### DIFF
--- a/generateNotes.js
+++ b/generateNotes.js
@@ -1,11 +1,6 @@
 const changelog = require('conventional-changelog')
 const parseUrl = require('github-url-from-git')
-const execSync = require('child_process').execSync;
-
-const lastTag = () => execSync(
-    'git describe --tags --match "v[0-9]*" --exclude="*dev*" --abbrev=0 origin/master',
-    { encoding: 'utf8' }
-).trim();
+const lastTag = require('./lastTag');
 
 module.exports = function (pluginConfig, {pkg}, cb) {
   const repository = pkg.repository ? parseUrl(pkg.repository.url) : null

--- a/getLastRelease.js
+++ b/getLastRelease.js
@@ -1,4 +1,5 @@
 const defaultLastRelease = require('@semantic-release/last-release-npm');
+const lastTag = require('./lastTag');
 
 module.exports = function (pluginConfig, config, cb) {
   let branch;
@@ -20,7 +21,7 @@ module.exports = function (pluginConfig, config, cb) {
 
   return defaultLastRelease(pluginConfig, config, function(err, res) {
     if (!res.gitHead) {
-      res.gitHead = 'origin/master';
+      res.gitHead = lastTag();
     }
 
     if (distTag) {

--- a/lastTag.js
+++ b/lastTag.js
@@ -1,0 +1,8 @@
+const execSync = require('child_process').execSync;
+
+const lastTag = () => execSync(
+    'git describe --tags --match "v[0-9]*" --exclude="*dev*" --abbrev=0 origin/master',
+    { encoding: 'utf8' }
+).trim();
+
+module.exports = lastTag;


### PR DESCRIPTION
My last fix in #9 actually made it impossible to release from master.