### PR TITLE
fix: abort release-master if dev dependencies are found

### DIFF
--- a/bin/find-dev-deps.js
+++ b/bin/find-dev-deps.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const json = fs.readFileSync('package.json', { encoding: 'utf-8' });
+const meta = JSON.parse(json);
+const deps = Object.assign({}, meta.dependencies, meta.peerDependencies);
+
+Object.keys(deps).forEach((key) => {
+    if (deps[key].indexOf('dev') !== -1) {
+        process.exit(-1);
+    }
+});
+

--- a/bin/find-dev-deps.js
+++ b/bin/find-dev-deps.js
@@ -7,7 +7,7 @@ const deps = Object.assign({}, meta.dependencies, meta.peerDependencies);
 
 Object.keys(deps).forEach((key) => {
     if (deps[key].indexOf('dev') !== -1) {
-        process.exit(-1);
+        // "dev" dependencies found, exit with error
+        process.exit(1);
     }
 });
-

--- a/bin/release-master
+++ b/bin/release-master
@@ -15,8 +15,8 @@ git reset --hard origin/master
 git merge --ff-only --quiet origin/develop
 set +o errexit
 
-grep "[@-]dev" package.json
-if [ $? -eq 0 ]; then
+./node_modules/.bin/find-dev-deps
+if [ $? -ne 0 ]; then
     echo "Found reference to @dev packages. Aborting."
     exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "version": "0.0.0-semantically-released",
   "main": "./bin/semantic-prerelease.js",
   "bin": {
+    "find-dev-deps": "./bin/find-dev-deps.js",
     "semantic-prerelease": "./bin/semantic-prerelease.js",
     "release-master": "./bin/release-master"
   },


### PR DESCRIPTION
The current check will fail with the following dependency:

`"@foo": "dev"`