### PR TITLE
fix: update semantic-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-eslint": "^7.2.3",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^3.19.0",
-    "semantic-release": "^6.3.6",
     "validate-commit-msg": "^1.1.1"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@krux/condition-jenkins": "^1.0.1",
-    "semantic-release": "^4.3.5"
+    "semantic-release": "^6.3.6"
   },
   "engines": {
     "node": ">=4.2.0",
@@ -38,7 +38,7 @@
     "babel-eslint": "^7.2.3",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^3.19.0",
-    "semantic-release": "^4.3.5",
+    "semantic-release": "^6.3.6",
     "validate-commit-msg": "^1.1.1"
   },
   "config": {


### PR DESCRIPTION
Since 8th of September, the github API has been modified and no-longer accepts authentication through query parameter:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Since the deprecation, the `kendo-react-private` publish build no longer works, and throws an error regarding the query authentication:
https://github.com/telerik/kendo-react-private/runs/3548378720

A further deep-dive reveals that the problems comes from an outdated version of the [`github`](https://www.npmjs.com/package/github) package (currently `0.2.4`) &mdash; the package is a dependency of the `semantic-release` package which we're using here.

Updating the `semantic-release` version to at least `6.3.6` should bump the `github` package to `8.2.1` and resolve the problem.

As a side note, all `kendo-angular-*` packages already have hard-coded `semantic-release@^6.3.6` and seems unaffected by the recent deprecation:
https://github.com/telerik/kendo-angular-dateinputs/blob/aeebbb42fc48ce83f1c760418ac09f54d667e615/package.json#L107

cc, @telerik/web-components-lt &mdash; If any of your packages are using `@telerik/semantic-prerelease` you might experience this issue as well.