### PR TITLE
fix: update semantic-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,13 @@
   "author": "Telerik",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@semantic-release/last-release-npm": "^2.0.2",
     "@telerik/eslint-config": "1.1.0",
     "babel-eslint": "^7.2.3",
+    "conventional-changelog": "^3.1.24",
     "cz-conventional-changelog": "^1.1.5",
     "eslint": "^3.19.0",
+    "github-url-from-git": "^1.5.0",
     "validate-commit-msg": "^1.1.1"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "@krux/condition-jenkins": "^1.0.1",
-    "semantic-release": "^6.3.6"
+    "semantic-release": "17.2.3"
   },
   "engines": {
     "node": ">=4.2.0",


### PR DESCRIPTION
We have recently received a security-vulnerability notification from `dependabot` in the `kendo-react-private` repository, about [CVE-2020-26226](https://github.com/semantic-release/semantic-release/security/advisories/GHSA-r2j6-p67h-q639). Due to the way dependabot works (checks for vulnerabilities after a commit), we would be seeing the notification in other repositories soon.

Updating the package to version `17.2.3` would be enough for patching the vulnerability and should not require any changes from our side (at least from my local testing). Updating to `latest`(18) would require us to bump the `node` version ot `>14` which I'm afraid is not possible at the moment.